### PR TITLE
Update multimc5-9999.ebuild

### DIFF
--- a/games-action/multimc5/multimc5-9999.ebuild
+++ b/games-action/multimc5/multimc5-9999.ebuild
@@ -31,10 +31,6 @@ RDEPEND="${COMMON_DEPEND}
 		virtual/jre
 		virtual/opengl"
 
-PATCHES=(
-		"${FILESDIR}/fortify-fix.patch"
-)
-
 src_prepare() {
 	git submodule update --init
 	cmake-utils_src_prepare


### PR DESCRIPTION
fortify-fix.patch no longer works and should not be needed